### PR TITLE
Add mining gloves IDs to ArmorCase list.

### DIFF
--- a/src/main/java/com/CosRoom/items/ArmorCase.java
+++ b/src/main/java/com/CosRoom/items/ArmorCase.java
@@ -132,6 +132,9 @@ public class ArmorCase {
         this.ArmorCaseHash.add(ItemID.LUMBERJACK_LEGS);
         this.ArmorCaseHash.add(ItemID.LUMBERJACK_BOOTS);
         this.ArmorCaseHash.add(ItemID.GAS_MASK);
+        this.ArmorCaseHash.add(ItemID.MINING_GLOVES);
+        this.ArmorCaseHash.add(ItemID.SUPERIOR_MINING_GLOVES);
+        this.ArmorCaseHash.add(ItemID.EXPERT_MINING_GLOVES);
         this.ArmorCaseHash.add(ItemID.MOURNER_TOP);
         this.ArmorCaseHash.add(ItemID.MOURNER_TROUSERS);
         this.ArmorCaseHash.add(ItemID.MOURNER_GLOVES);


### PR DESCRIPTION
Just ran into this. I can modify the items to be alphabetically sorted, or you might want to parse from the wiki again. I **did not** double check if there are other items missing from the list.

As per the wiki "Changes":
All variants of mining gloves can now be stored in the armour case of a player's costume room.
https://oldschool.runescape.wiki/w/Expert_mining_gloves
[16 November](https://oldschool.runescape.wiki/w/16_November) [2022](https://oldschool.runescape.wiki/w/2022)




