### PR TITLE
Replace config group name

### DIFF
--- a/src/main/java/com/CosRoom/CosRoomConfig.java
+++ b/src/main/java/com/CosRoom/CosRoomConfig.java
@@ -5,7 +5,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import java.awt.Color;
 
-@ConfigGroup("example")
+@ConfigGroup("costumeroomchecker")
 public interface CosRoomConfig extends Config
 {
 	@ConfigItem(


### PR DESCRIPTION
Never got changed off the example plugin, can't believe I never noticed.